### PR TITLE
Test case bug - fixed

### DIFF
--- a/spaceman/tests/test_game_model.py
+++ b/spaceman/tests/test_game_model.py
@@ -52,7 +52,7 @@ class GameModelTests( TestCase ):
         )
 
         game.handleGuess('X')
-        self.assertEquals( expectedGuessesTaken, game.guesses_taken )
+        self.assertEquals( expectedGuessesTaken + 1, game.guesses_taken )
     
 
     ### guessed_word_state field


### PR DESCRIPTION
References #3 
Game class was fine, but the logic in the test case was not correct.
The test variable "expectedGuessesTaken" did not account for the increase after an incorrect guess.